### PR TITLE
docker-composeのenv_file設定値がdev.ymlを参照するように修正

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,7 +1,6 @@
 version: '3'
 services:
   web:
-    build: .
     command: yarn dev
     env_file: .env.development
     volumes:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,7 @@
 version: '3'
 services:
   web:
+    build: .
     command: yarn dev
     env_file: .env.development
     volumes:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+  web:
+    build: .
+    image: ktmouk/hackaru-web:latest
+    env_file: .env.production

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,6 +1,4 @@
 version: '3'
 services:
   web:
-    build: .
-    image: ktmouk/hackaru-web:latest
     env_file: .env.production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,7 @@
 version: '3'
 services:
   web:
+    build: .
+    image: ktmouk/hackaru-web:latest
     ports:
       - 3333:3333

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,5 @@
 version: '3'
 services:
   web:
-    build: .
-    image: ktmouk/hackaru-web:latest
-    env_file: .env.production
     ports:
       - 3333:3333


### PR DESCRIPTION
# 修正内容

開発環境で`docker-compose -f docker-compose.yml -f docker-compose.dev.yml up `を実行すると`.env.development`を正しく参照しないバグの修正。

# オーナーへのお願い

変更後、本番環境では、`docker-compose.yml`に加えて`docker-compose.prod.yml`も参照する必要があります。