### PR TITLE
ダークモードでReportのborderの色が白い問題を修正

### DIFF
--- a/components/atoms/bar-chart.vue
+++ b/components/atoms/bar-chart.vue
@@ -48,6 +48,7 @@ options.dark = merge({}, options.default, {
           fontColor: '#cdd0d1'
         },
         gridLines: {
+          zeroLineColor: '#3a4357',
           color: '#3a4357'
         }
       }


### PR DESCRIPTION
- ダークモード用の `zeroLineColor` の設定を追加