### PR TITLE
言語の設定をAPIサーバに送信するように変更

### DIFF
--- a/__tests__/components/molecules/locale-select.spec.js
+++ b/__tests__/components/molecules/locale-select.spec.js
@@ -1,3 +1,4 @@
+import { Store } from 'vuex-mock-store';
 import { shallowMount } from '@vue/test-utils';
 import LocaleSelect from '@/components/molecules/locale-select';
 
@@ -5,6 +6,7 @@ describe('LocaleSelect', () => {
   let factory;
   let wrapper;
 
+  const $store = new Store({});
   const switchLocalePath = jest.fn();
   const setLocaleCookie = jest.fn();
   const $router = { push: jest.fn() };
@@ -13,6 +15,7 @@ describe('LocaleSelect', () => {
     factory = () =>
       shallowMount(LocaleSelect, {
         mocks: {
+          $store,
           switchLocalePath,
           $router,
           $i18n: {
@@ -29,10 +32,10 @@ describe('LocaleSelect', () => {
       wrapper.find({ ref: 'base-select' }).vm.$emit('change', 'ja');
     });
 
-    it('change locale', () => {
-      expect(switchLocalePath).toHaveBeenCalledWith('ja');
-      expect(setLocaleCookie).toHaveBeenCalledWith('ja');
-      expect($router.push).toHaveBeenCalled();
+    it('dispatch user/update', () => {
+      expect($store.dispatch).toHaveBeenCalledWith('user/update', {
+        locale: 'ja'
+      });
     });
   });
 });

--- a/__tests__/pages/auth.spec.js
+++ b/__tests__/pages/auth.spec.js
@@ -22,7 +22,15 @@ describe('Auth', () => {
     $route.query['sign-up'] = false;
     factory = () =>
       shallowMount(Auth, {
-        mocks: { $store, $route, $router, $env }
+        mocks: {
+          $store,
+          $route,
+          $router,
+          $env,
+          $i18n: {
+            locale: 'en'
+          }
+        }
       });
   });
 
@@ -114,7 +122,8 @@ describe('Auth', () => {
       expect($store.dispatch).toHaveBeenCalledWith('auth/signUp', {
         email: 'example@example.com',
         password: 'password',
-        passwordConfirmation: 'confirmation'
+        passwordConfirmation: 'confirmation',
+        locale: 'en'
       });
     });
   });

--- a/__tests__/store/users/mutations.spec.js
+++ b/__tests__/store/users/mutations.spec.js
@@ -9,10 +9,15 @@ describe('Mutations', () => {
     };
 
     beforeEach(() => {
+      mutations.$i18n = {
+        setLocaleCookie: jest.fn(),
+        locale: 'en'
+      };
       mutations['SET_USER'](state, {
         timeZone: 'Asia/Tokyo',
         receiveWeekReport: true,
-        receiveMonthReport: true
+        receiveMonthReport: true,
+        locale: 'ja'
       });
     });
 
@@ -20,6 +25,11 @@ describe('Mutations', () => {
       expect(state.timeZone).toBe('Asia/Tokyo');
       expect(state.receiveWeekReport).toBe(true);
       expect(state.receiveMonthReport).toBe(true);
+    });
+
+    it('set locale', () => {
+      expect(mutations.$i18n.setLocaleCookie).toHaveBeenCalledWith('ja');
+      expect(mutations.$i18n.locale).toBe('ja');
     });
   });
 });

--- a/assets/locales/components/molecules/locale-select.json
+++ b/assets/locales/components/molecules/locale-select.json
@@ -1,0 +1,8 @@
+{
+  "en": {
+    "changed": "Locale changed"
+  },
+  "ja": {
+    "changed": "言語を変更しました"
+  }
+}

--- a/assets/locales/components/organisms/setting-locale-select.json
+++ b/assets/locales/components/organisms/setting-locale-select.json
@@ -1,6 +1,6 @@
 {
   "en": {
-    "title": "Language"
+    "title": "Locale"
   },
   "ja": {
     "title": "言語を設定"

--- a/components/molecules/locale-select.vue
+++ b/components/molecules/locale-select.vue
@@ -1,3 +1,5 @@
+<i18n src="@/assets/locales/components/molecules/locale-select.json"></i18n>
+
 <template>
   <base-select
     ref="base-select"
@@ -31,9 +33,9 @@ export default {
     };
   },
   methods: {
-    change(locale) {
-      this.$i18n.setLocaleCookie(locale);
-      this.$router.push(this.switchLocalePath(locale));
+    async change(locale) {
+      const success = await this.$store.dispatch('user/update', { locale });
+      if (success) this.$store.dispatch('toast/success', this.$t('changed'));
     }
   }
 };

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -135,9 +135,12 @@ module.exports = {
     [
       'nuxt-i18n',
       {
-        locales: [{ code: 'ja', iso: 'ja' }, { code: 'en', iso: 'en-US' }],
+        locales: ['ja', 'en'],
         defaultLocale: 'en',
         vueI18nLoader: true,
+        vueI18n: {
+          fallbackLocale: 'en'
+        },
         detectBrowserLanguage: {
           alwaysRedirect: true
         }

--- a/pages/auth.vue
+++ b/pages/auth.vue
@@ -140,7 +140,8 @@ export default {
       const success = await this.$store.dispatch('auth/signUp', {
         email: this.email,
         password: this.password,
-        passwordConfirmation: this.passwordConfirmation
+        passwordConfirmation: this.passwordConfirmation,
+        locale: this.$i18n.locale
       });
       if (success) {
         localStorage.setItem('userId', this.$store.getters['auth/userId']);

--- a/store/auth.js
+++ b/store/auth.js
@@ -65,7 +65,7 @@ export const actions = {
   },
   async signUp(
     { commit, dispatch },
-    { email, password, passwordConfirmation }
+    { email, password, passwordConfirmation, locale }
   ) {
     try {
       const res = await dispatch(
@@ -78,6 +78,7 @@ export const actions = {
               email,
               password,
               passwordConfirmation,
+              locale,
               timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone
             }
           }

--- a/store/user.js
+++ b/store/user.js
@@ -51,6 +51,8 @@ export const mutations = {
     state.timeZone = payload.timeZone;
     state.receiveWeekReport = payload.receiveWeekReport;
     state.receiveMonthReport = payload.receiveMonthReport;
+    this.$i18n.setLocaleCookie(payload.locale);
+    this.$i18n.locale = payload.locale;
   }
 };
 


### PR DESCRIPTION
- PDFやレポートメールの多言語対応のため