### PR TITLE
ログイン前画面の言語のセレクトボックスが反応しない問題を修正

### DIFF
--- a/__tests__/components/molecules/locale-select.spec.js
+++ b/__tests__/components/molecules/locale-select.spec.js
@@ -7,27 +7,38 @@ describe('LocaleSelect', () => {
   let wrapper;
 
   const $store = new Store({});
-  const switchLocalePath = jest.fn();
-  const setLocaleCookie = jest.fn();
-  const $router = { push: jest.fn() };
+  const setLocale = jest.fn();
 
   beforeEach(() => {
     factory = () =>
       shallowMount(LocaleSelect, {
         mocks: {
           $store,
-          switchLocalePath,
-          $router,
           $i18n: {
+            setLocale,
             locale: 'en',
-            setLocaleCookie
+            locales: [
+              {
+                code: 'en',
+                name: 'English'
+              },
+              {
+                code: 'ja',
+                name: '日本語'
+              }
+            ]
           }
         }
       });
   });
 
-  describe('when select', () => {
+  it('has selected value correctly', () => {
+    expect(factory().find({ ref: 'base-select' }).vm.value).toEqual('English');
+  });
+
+  describe('when select and user is logged in', () => {
     beforeEach(() => {
+      $store.getters['auth/loggedIn'] = true;
       wrapper = factory();
       wrapper.find({ ref: 'base-select' }).vm.$emit('change', 'ja');
     });
@@ -36,6 +47,18 @@ describe('LocaleSelect', () => {
       expect($store.dispatch).toHaveBeenCalledWith('user/update', {
         locale: 'ja'
       });
+    });
+  });
+
+  describe('when select and user is not logged in', () => {
+    beforeEach(() => {
+      $store.getters['auth/loggedIn'] = false;
+      wrapper = factory();
+      wrapper.find({ ref: 'base-select' }).vm.$emit('change', 'ja');
+    });
+
+    it('set locale', () => {
+      expect(setLocale).toHaveBeenCalledWith('ja');
     });
   });
 });

--- a/__tests__/store/users/mutations.spec.js
+++ b/__tests__/store/users/mutations.spec.js
@@ -10,8 +10,7 @@ describe('Mutations', () => {
 
     beforeEach(() => {
       mutations.$i18n = {
-        setLocaleCookie: jest.fn(),
-        locale: 'en'
+        setLocale: jest.fn()
       };
       mutations['SET_USER'](state, {
         timeZone: 'Asia/Tokyo',
@@ -28,8 +27,7 @@ describe('Mutations', () => {
     });
 
     it('set locale', () => {
-      expect(mutations.$i18n.setLocaleCookie).toHaveBeenCalledWith('ja');
-      expect(mutations.$i18n.locale).toBe('ja');
+      expect(mutations.$i18n.setLocale).toHaveBeenCalledWith('ja');
     });
   });
 });

--- a/assets/locales/components/molecules/locale-select.json
+++ b/assets/locales/components/molecules/locale-select.json
@@ -1,8 +1,0 @@
-{
-  "en": {
-    "changed": "Locale changed"
-  },
-  "ja": {
-    "changed": "言語を変更しました"
-  }
-}

--- a/components/molecules/locale-select.vue
+++ b/components/molecules/locale-select.vue
@@ -1,41 +1,40 @@
-<i18n src="@/assets/locales/components/molecules/locale-select.json"></i18n>
-
 <template>
-  <base-select
-    ref="base-select"
-    :value="locales[$i18n.locale]"
-    @change="change"
-  >
+  <base-select ref="base-select" :value="selectedLocale" @change="change">
     <option
-      v-for="(locale, key) in locales"
-      :key="key"
-      :value="key"
-      :selected="key === $i18n.locale"
+      v-for="{ name, code } in $i18n.locales"
+      :key="code"
+      :value="code"
+      :selected="code === $i18n.locale"
     >
-      {{ locale }}
+      {{ name }}
     </option>
   </base-select>
 </template>
 
 <script>
+import { mapGetters } from 'vuex';
 import BaseSelect from '@/components/molecules/base-select';
 
 export default {
   components: {
     BaseSelect
   },
-  data() {
-    return {
-      locales: {
-        en: 'English',
-        ja: '日本語'
-      }
-    };
+  computed: {
+    ...mapGetters({
+      loggedIn: 'auth/loggedIn'
+    }),
+    selectedLocale() {
+      return this.$i18n.locales.find(({ code }) => this.$i18n.locale === code)
+        .name;
+    }
   },
   methods: {
-    async change(locale) {
-      const success = await this.$store.dispatch('user/update', { locale });
-      if (success) this.$store.dispatch('toast/success', this.$t('changed'));
+    change(locale) {
+      if (this.loggedIn) {
+        this.$store.dispatch('user/update', { locale });
+      } else {
+        this.$i18n.setLocale(locale);
+      }
     }
   }
 };

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -135,13 +135,23 @@ module.exports = {
     [
       'nuxt-i18n',
       {
-        locales: ['ja', 'en'],
+        locales: [
+          {
+            code: 'ja',
+            name: '日本語'
+          },
+          {
+            code: 'en',
+            name: 'English'
+          }
+        ],
         defaultLocale: 'en',
         vueI18nLoader: true,
         vueI18n: {
           fallbackLocale: 'en'
         },
         detectBrowserLanguage: {
+          useCookie: true,
           alwaysRedirect: true
         }
       }

--- a/store/user.js
+++ b/store/user.js
@@ -51,8 +51,7 @@ export const mutations = {
     state.timeZone = payload.timeZone;
     state.receiveWeekReport = payload.receiveWeekReport;
     state.receiveMonthReport = payload.receiveMonthReport;
-    this.$i18n.setLocaleCookie(payload.locale);
-    this.$i18n.locale = payload.locale;
+    this.$i18n.setLocale(payload.locale);
   }
 };
 


### PR DESCRIPTION
- ログイン済み前提の処理になっていたため、正しく動作しなかった。
  - ログイン前の場合はCookieに保存する処理のみ実行するように修正。